### PR TITLE
Fix observable variable crashing when set to null

### DIFF
--- a/Runtime/Utilities/ObservableVariable.cs
+++ b/Runtime/Utilities/ObservableVariable.cs
@@ -15,7 +15,7 @@ namespace StorkStudios.CoreNest
             get => current;
             set
             {
-                if (current.Equals(value))
+                if ((current != null && current.Equals(value)) || value == null)
                 {
                     return;
                 }


### PR DESCRIPTION
Jeśli current jest nullem, to wywołuje `Equals` na nullu i się crashuje